### PR TITLE
Close watcher at disconnect instead of emitting an error on it

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "git://github.com/c9/vfs-socket.git"
     },
     "dependencies": {
-        "smith": "~0.1.16"
+        "smith": "git://github.com/rocketpack/smith.git"
     },
     "devDependencies": {
         "chai": "~1.2.0",

--- a/worker.js
+++ b/worker.js
@@ -121,7 +121,7 @@ function Worker(vfs) {
         Object.keys(watchers).forEach(function (id) {
             var watcher = watchers[id];
             delete watchers[id];
-            watcher.emit("error", err);
+            watcher.close();
         });
     });
 


### PR DESCRIPTION
Don't emit an error from watchers being cleaned up at disconnect - just close the watcher instead. Fixes a crash when setting a watcher, then disconnecting the other end (as there is no way to catch the error)
